### PR TITLE
some ui updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,9 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[css]": {
+    "editor.formatOnSave": false
+  },
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.workingDirectories": [
     { "pattern": "app/*" },

--- a/app/globals.css
+++ b/app/globals.css
@@ -312,21 +312,3 @@
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
 }
-
-@keyframes pulse {
-  0% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.5;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}
-
-.animate-pulse {
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -312,3 +312,21 @@
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
 }
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -85,7 +85,7 @@
         "noHeadImportInDocument": "warn",
         "noIrregularWhitespace": "warn",
         "noStaticElementInteractions": "warn",
-        "useSortedClasses": "error",
+        "useSortedClasses": "off",
         "useValidAutocomplete": "warn"
       }
     }

--- a/components/elements/tool.tsx
+++ b/components/elements/tool.tsx
@@ -14,6 +14,7 @@ import {
   CircleIcon,
   ClockIcon,
   Loader2Icon,
+  ScanTextIcon,
   TextSearchIcon,
   WrenchIcon,
   XCircleIcon,
@@ -80,6 +81,10 @@ const ToolIcon = ({ type }: { type: ToolUIPart['type'] }) => {
       return (
         <TextSearchIcon className={generalClasses} strokeWidth={strokeWidth} />
       );
+    case 'tool-scrapeUrl':
+      return (
+        <ScanTextIcon className={generalClasses} strokeWidth={strokeWidth} />
+      );
     default:
       return (
         <WrenchIcon className={generalClasses} strokeWidth={strokeWidth} />
@@ -91,7 +96,9 @@ const getToolTitle = (type: ToolUIPart['type']) => {
   const t = useTranslations('Tool');
   switch (type) {
     case 'tool-searchWeb':
-      return t('title.searchWeb');
+      return t('searchWeb.title');
+    case 'tool-scrapeUrl':
+      return t('scrapeUrl.title');
     default:
       return type;
   }
@@ -165,14 +172,14 @@ export const ToolOutput = ({
   if (!(output || errorText)) {
     return null;
   }
-
+  const t = useTranslations('Tool');
   return (
     <div
       className={cn('min-w-0 max-w-full space-y-2 p-4', className)}
       {...props}
     >
       <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-        {errorText ? 'Error' : 'Result'}
+        {errorText ? t('error') : t('result')}
       </h4>
       <div
         className={cn(

--- a/components/elements/tool.tsx
+++ b/components/elements/tool.tsx
@@ -92,41 +92,44 @@ const ToolIcon = ({ type }: { type: ToolUIPart['type'] }) => {
   }
 };
 
-const getToolTitle = (type: ToolUIPart['type']) => {
-  const t = useTranslations('Tool');
-  switch (type) {
-    case 'tool-searchWeb':
-      return t('searchWeb.title');
-    case 'tool-scrapeUrl':
-      return t('scrapeUrl.title');
-    default:
-      return type;
-  }
-};
-
 export const ToolHeader = ({
   className,
   type,
   state,
   ...props
-}: ToolHeaderProps) => (
-  <CollapsibleTrigger
-    className={cn(
-      'flex w-full min-w-0 items-center justify-between gap-2 p-3',
-      className,
-    )}
-    {...props}
-  >
-    <div className="flex min-w-0 flex-1 items-center gap-2">
-      <ToolIcon type={type} />
-      <span className="truncate font-medium text-sm">{getToolTitle(type)}</span>
-    </div>
-    <div className="flex shrink-0 items-center gap-2">
-      {getStatusBadge(state)}
-      <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-    </div>
-  </CollapsibleTrigger>
-);
+}: ToolHeaderProps) => {
+  const t = useTranslations('Tool');
+
+  const getToolTitle = () => {
+    switch (type) {
+      case 'tool-searchWeb':
+        return t('searchWeb.title');
+      case 'tool-scrapeUrl':
+        return t('scrapeUrl.title');
+      default:
+        return type;
+    }
+  };
+
+  return (
+    <CollapsibleTrigger
+      className={cn(
+        'flex w-full min-w-0 items-center justify-between gap-2 p-3',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <ToolIcon type={type} />
+        <span className="truncate font-medium text-sm">{getToolTitle()}</span>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {getStatusBadge(state)}
+        <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+      </div>
+    </CollapsibleTrigger>
+  );
+};
 
 export type ToolContentProps = ComponentProps<typeof CollapsibleContent>;
 

--- a/components/elements/tool.tsx
+++ b/components/elements/tool.tsx
@@ -25,7 +25,7 @@ export type ToolProps = ComponentProps<typeof Collapsible>;
 
 export const Tool = ({ className, ...props }: ToolProps) => (
   <Collapsible
-    className={cn('not-prose mb-4 w-full rounded-md border', className)}
+    className={cn('not-prose mb-4 w-full min-w-0 rounded-md border', className)}
     {...props}
   />
 );
@@ -99,7 +99,7 @@ export type ToolContentProps = ComponentProps<typeof CollapsibleContent>;
 export const ToolContent = ({ className, ...props }: ToolContentProps) => (
   <CollapsibleContent
     className={cn(
-      'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 w-full overflow-hidden text-popover-foreground outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in',
+      'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 w-full min-w-0 overflow-hidden text-popover-foreground outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in',
       className,
     )}
     {...props}
@@ -111,11 +111,14 @@ export type ToolInputProps = ComponentProps<'div'> & {
 };
 
 export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
-  <div className={cn('space-y-2 overflow-hidden p-4', className)} {...props}>
+  <div
+    className={cn('min-w-0 space-y-2 overflow-hidden p-4', className)}
+    {...props}
+  >
     <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
       Parameters
     </h4>
-    <div className="rounded-md bg-muted/50">
+    <div className="min-w-0 rounded-md bg-muted/50">
       <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
     </div>
   </div>
@@ -137,20 +140,23 @@ export const ToolOutput = ({
   }
 
   return (
-    <div className={cn('space-y-2 p-4', className)} {...props}>
+    <div
+      className={cn('min-w-0 max-w-full space-y-2 p-4', className)}
+      {...props}
+    >
       <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
         {errorText ? 'Error' : 'Result'}
       </h4>
       <div
         className={cn(
-          'overflow-x-auto rounded-md text-xs [&_table]:w-full',
+          'min-w-0 max-w-full overflow-x-auto rounded-md text-xs [&_table]:w-full',
           errorText
             ? 'bg-destructive/10 text-destructive'
             : 'bg-muted/50 text-foreground',
         )}
       >
-        {errorText && <div>{errorText}</div>}
-        {output && <div>{output}</div>}
+        {errorText && <div className="break-words">{errorText}</div>}
+        {output && <div className="min-w-0 max-w-full">{output}</div>}
       </div>
     </div>
   );

--- a/components/elements/tool.tsx
+++ b/components/elements/tool.tsx
@@ -14,12 +14,14 @@ import {
   CircleIcon,
   ClockIcon,
   Loader2Icon,
+  TextSearchIcon,
   WrenchIcon,
   XCircleIcon,
 } from 'lucide-react';
 import type { ComponentProps, ReactNode } from 'react';
 import React from 'react';
 import { CodeBlock } from './code-block';
+import { useTranslations } from 'next-intl';
 
 export type ToolProps = ComponentProps<typeof Collapsible>;
 
@@ -70,6 +72,31 @@ const getStatusBadge = (status: ToolUIPart['state']) => {
   );
 };
 
+const ToolIcon = ({ type }: { type: ToolUIPart['type'] }) => {
+  const generalClasses = 'size-5 shrink-0 text-muted-foreground';
+  const strokeWidth = 1.5;
+  switch (type) {
+    case 'tool-searchWeb':
+      return (
+        <TextSearchIcon className={generalClasses} strokeWidth={strokeWidth} />
+      );
+    default:
+      return (
+        <WrenchIcon className={generalClasses} strokeWidth={strokeWidth} />
+      );
+  }
+};
+
+const getToolTitle = (type: ToolUIPart['type']) => {
+  const t = useTranslations('Tool');
+  switch (type) {
+    case 'tool-searchWeb':
+      return t('title.searchWeb');
+    default:
+      return type;
+  }
+};
+
 export const ToolHeader = ({
   className,
   type,
@@ -84,8 +111,8 @@ export const ToolHeader = ({
     {...props}
   >
     <div className="flex min-w-0 flex-1 items-center gap-2">
-      <WrenchIcon className="size-4 shrink-0 text-muted-foreground" />
-      <span className="truncate font-medium text-sm">{type}</span>
+      <ToolIcon type={type} />
+      <span className="truncate font-medium text-sm">{getToolTitle(type)}</span>
     </div>
     <div className="flex shrink-0 items-center gap-2">
       {getStatusBadge(state)}

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -94,6 +94,7 @@ const PurePreviewMessage = ({
   isArtifactVisible: boolean;
 }) => {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
+  const t = useTranslations('Tool');
 
   const attachmentsFromMessage = message.parts.filter(
     (part) => part.type === 'file',
@@ -451,7 +452,6 @@ const PurePreviewMessage = ({
                     const output = searchPart.output as
                       | SearchWebOutput
                       | undefined;
-                    const t = useTranslations('Tool');
                     return (
                       <Tool key={toolCallId} defaultOpen={true}>
                         <ToolHeader state={state} type="tool-searchWeb" />
@@ -552,7 +552,6 @@ const PurePreviewMessage = ({
                     const output = scrapePart.output as
                       | ScrapeUrlOutput
                       | undefined;
-                    const t = useTranslations('Tool');
                     return (
                       <Tool key={toolCallId} defaultOpen={true}>
                         <ToolHeader state={state} type="tool-scrapeUrl" />

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -500,7 +500,7 @@ const PurePreviewMessage = ({
                                       'number' && (
                                       <span>
                                         {' '}
-                                        • {t('results')}: {output.resultCount}
+                                        • {t('result')}: {output.resultCount}
                                       </span>
                                     )}
                                   </div>

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -247,7 +247,7 @@ const PurePreviewMessage = ({
                     );
                   }
 
-                  if (type === 'text') {
+                  if (type === 'text' && part.text?.trim().length > 0) {
                     if (mode === 'view') {
                       return (
                         <div key={key}>
@@ -432,16 +432,18 @@ const PurePreviewMessage = ({
                           {state === 'output-available' && (
                             <ToolOutput
                               output={
-                                <div className="space-y-3">
+                                <div className="min-w-0 space-y-3">
                                   {(part as any).output?.summary && (
-                                    <div className="rounded-md bg-muted/50 p-2 text-xs">
+                                    <div className="min-w-0 rounded-md bg-muted/50 p-2 text-xs">
                                       <div className="font-medium">Summary</div>
-                                      <div>{(part as any).output.summary}</div>
+                                      <div className="break-words">
+                                        {(part as any).output.summary}
+                                      </div>
                                     </div>
                                   )}
-                                  <div className="text-muted-foreground text-xs">
+                                  <div className="min-w-0 break-words text-muted-foreground text-xs">
                                     Query:{' '}
-                                    <span className="font-medium">
+                                    <span className="break-all font-medium">
                                       {(part as any).output?.query ??
                                         (part as any).input?.query}
                                     </span>
@@ -463,20 +465,20 @@ const PurePreviewMessage = ({
                                           (r: any, i: number) => (
                                             <div
                                               key={r.url ?? i}
-                                              className="rounded-md border bg-background p-2"
+                                              className="min-w-0 rounded-md border bg-background p-2"
                                             >
-                                              <div className="truncate font-medium text-xs">
+                                              <div className="min-w-0 break-words font-medium text-xs">
                                                 <a
                                                   href={r.url}
                                                   target="_blank"
                                                   rel="noreferrer"
-                                                  className="underline"
+                                                  className="break-all underline"
                                                 >
                                                   {r.title || r.url}
                                                 </a>
                                               </div>
                                               {r.description && (
-                                                <div className="mt-1 line-clamp-3 text-muted-foreground text-xs">
+                                                <div className="mt-1 line-clamp-3 break-words text-muted-foreground text-xs">
                                                   {r.description}
                                                 </div>
                                               )}
@@ -533,66 +535,68 @@ const PurePreviewMessage = ({
                           {state === 'output-available' && (
                             <ToolOutput
                               output={
-                                <div className="space-y-3">
-                                  <div className="text-muted-foreground text-xs">
+                                <div className="min-w-0 space-y-3">
+                                  <div className="min-w-0 break-words text-muted-foreground text-xs">
                                     Scraped:{' '}
-                                    <span className="font-medium">
+                                    <span className="break-all font-medium">
                                       {(part as any).output?.url ||
                                         (part as any).input?.url}
                                     </span>
                                   </div>
                                   {(part as any).output?.data?.metadata && (
-                                    <div className="rounded-md border bg-background p-2 text-xs">
+                                    <div className="min-w-0 rounded-md border bg-background p-2 text-xs">
                                       <div className="font-medium">
                                         Metadata
                                       </div>
                                       <div className="mt-1 grid grid-cols-1 gap-1 sm:grid-cols-2">
-                                        <div>
+                                        <div className="min-w-0 break-words">
                                           Title:{' '}
                                           {
                                             (part as any).output.data.metadata
                                               .title
                                           }
                                         </div>
-                                        <div>
+                                        <div className="min-w-0 break-words">
                                           Language:{' '}
                                           {(part as any).output.data.metadata
                                             .language || 'n/a'}
                                         </div>
-                                        <div>
+                                        <div className="min-w-0 break-words">
                                           Status:{' '}
                                           {String(
                                             (part as any).output.data.metadata
                                               .statusCode ?? 'n/a',
                                           )}
                                         </div>
-                                        <div>
+                                        <div className="min-w-0 break-words">
                                           Source:{' '}
-                                          {
-                                            (part as any).output.data.metadata
-                                              .sourceURL
-                                          }
+                                          <span className="break-all">
+                                            {
+                                              (part as any).output.data.metadata
+                                                .sourceURL
+                                            }
+                                          </span>
                                         </div>
                                       </div>
                                     </div>
                                   )}
                                   {(part as any).output?.data?.markdown && (
-                                    <div className="rounded-md bg-muted/50 p-2 text-xs">
+                                    <div className="min-w-0 max-w-full rounded-md bg-muted/50 p-2 text-xs">
                                       <div className="font-medium">
                                         Markdown (preview)
                                       </div>
-                                      <div className="mt-1 line-clamp-6 whitespace-pre-wrap">
+                                      <div className="mt-1 line-clamp-6 max-w-full whitespace-pre-wrap break-all [&_a]:break-all [&_a]:underline">
                                         {(
                                           part as any
                                         ).output.data.markdown.slice(0, 2000)}
                                       </div>
                                     </div>
                                   )}
-                                  <details className="rounded-md border p-2 text-xs">
+                                  <details className="min-w-0 max-w-full overflow-hidden rounded-md border p-2 text-xs">
                                     <summary className="cursor-pointer select-none font-medium">
                                       Raw JSON
                                     </summary>
-                                    <div className="mt-2">
+                                    <div className="mt-2 min-w-0 max-w-full overflow-hidden">
                                       <CodeBlock
                                         code={JSON.stringify(
                                           (part as any).output,

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -26,6 +26,7 @@ import { MessageReasoning } from './message-reasoning';
 import { PreviewAttachment } from './preview-attachment';
 import { Weather } from './weather';
 import { CodeBlock } from './elements/code-block';
+import { useTranslations } from 'next-intl';
 
 type MessagePart = UIMessagePart<CustomUIDataTypes, ChatTools>;
 
@@ -450,7 +451,7 @@ const PurePreviewMessage = ({
                     const output = searchPart.output as
                       | SearchWebOutput
                       | undefined;
-
+                    const t = useTranslations('Tool');
                     return (
                       <Tool key={toolCallId} defaultOpen={true}>
                         <ToolHeader state={state} type="tool-searchWeb" />
@@ -479,17 +480,19 @@ const PurePreviewMessage = ({
                           {state === 'output-available' && (
                             <ToolOutput
                               output={
-                                <div className="min-w-0 space-y-3">
+                                <div className="min-w-0 space-y-3 p-2">
                                   {output?.summary && (
                                     <div className="min-w-0 rounded-md bg-muted/50 p-2 text-xs">
-                                      <div className="font-medium">Summary</div>
+                                      <div className="font-medium">
+                                        {t('searchWeb.summary')}
+                                      </div>
                                       <div className="break-words">
                                         {output.summary}
                                       </div>
                                     </div>
                                   )}
                                   <div className="min-w-0 break-words text-muted-foreground text-xs">
-                                    Query:{' '}
+                                    {t('searchWeb.query')}:{' '}
                                     <span className="break-all font-medium">
                                       {output?.query ?? searchPart.input?.query}
                                     </span>
@@ -497,7 +500,7 @@ const PurePreviewMessage = ({
                                       'number' && (
                                       <span>
                                         {' '}
-                                        • Results: {output.resultCount}
+                                        • {t('results')}: {output.resultCount}
                                       </span>
                                     )}
                                   </div>
@@ -549,7 +552,7 @@ const PurePreviewMessage = ({
                     const output = scrapePart.output as
                       | ScrapeUrlOutput
                       | undefined;
-
+                    const t = useTranslations('Tool');
                     return (
                       <Tool key={toolCallId} defaultOpen={true}>
                         <ToolHeader state={state} type="tool-scrapeUrl" />
@@ -580,7 +583,7 @@ const PurePreviewMessage = ({
                               output={
                                 <div className="min-w-0 space-y-3">
                                   <div className="min-w-0 break-words text-muted-foreground text-xs">
-                                    Scraped:{' '}
+                                    {t('scrapeUrl.scraped')}:{' '}
                                     <span className="break-all font-medium">
                                       {output?.url || scrapePart.input?.url}
                                     </span>
@@ -588,26 +591,27 @@ const PurePreviewMessage = ({
                                   {output?.data?.metadata && (
                                     <div className="min-w-0 rounded-md border bg-background p-2 text-xs">
                                       <div className="font-medium">
-                                        Metadata
+                                        {t('scrapeUrl.metadata')}
                                       </div>
                                       <div className="mt-1 grid grid-cols-1 gap-1 sm:grid-cols-2">
                                         <div className="min-w-0 break-words">
-                                          Title: {output.data.metadata.title}
+                                          {t('scrapeUrl.outputTitle')}:{' '}
+                                          {output.data.metadata.title}
                                         </div>
                                         <div className="min-w-0 break-words">
-                                          Language:{' '}
+                                          {t('scrapeUrl.language')}:{' '}
                                           {output.data.metadata.language ||
                                             'n/a'}
                                         </div>
                                         <div className="min-w-0 break-words">
-                                          Status:{' '}
+                                          {t('scrapeUrl.statusCode')}:{' '}
                                           {String(
                                             output.data.metadata.statusCode ??
                                               'n/a',
                                           )}
                                         </div>
                                         <div className="min-w-0 break-words">
-                                          Source:{' '}
+                                          {t('scrapeUrl.sourceURL')}:{' '}
                                           <span className="break-all">
                                             {output.data.metadata.sourceURL}
                                           </span>
@@ -618,7 +622,7 @@ const PurePreviewMessage = ({
                                   {output?.data?.markdown && (
                                     <div className="min-w-0 max-w-full rounded-md bg-muted/50 p-2 text-xs">
                                       <div className="font-medium">
-                                        Markdown (preview)
+                                        {t('scrapeUrl.markdown')}
                                       </div>
                                       <div className="mt-1 line-clamp-6 max-w-full whitespace-pre-wrap break-all [&_a]:break-all [&_a]:underline">
                                         {output.data.markdown.slice(0, 2000)}

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -3,8 +3,9 @@ import type { UseChatHelpers } from '@ai-sdk/react';
 import equal from 'fast-deep-equal';
 import { motion } from 'framer-motion';
 import { memo, useState } from 'react';
+import type { UIMessagePart } from 'ai';
 import type { Vote } from '@/lib/db/schema';
-import type { ChatMessage } from '@/lib/types';
+import type { ChatMessage, ChatTools, CustomUIDataTypes } from '@/lib/types';
 import { cn, sanitizeText } from '@/lib/utils';
 import { useDataStream } from './data-stream-provider';
 import { DocumentToolResult } from './document';
@@ -25,6 +26,50 @@ import { MessageReasoning } from './message-reasoning';
 import { PreviewAttachment } from './preview-attachment';
 import { Weather } from './weather';
 import { CodeBlock } from './elements/code-block';
+
+type MessagePart = UIMessagePart<CustomUIDataTypes, ChatTools>;
+
+type SearchWebOutput = {
+  query?: string;
+  resultCount?: number;
+  results?: Array<{
+    title?: string;
+    url: string;
+    description?: string;
+  }>;
+  summary?: string | null;
+  privacy_notice?: string;
+};
+
+type ScrapeUrlOutput = {
+  url: string;
+  success: boolean;
+  data?: {
+    markdown?: string;
+    html?: string;
+    metadata?: {
+      title: string;
+      description?: string;
+      language?: string | null;
+      sourceURL: string;
+      statusCode?: number | null;
+      ogTitle?: string;
+      ogDescription?: string;
+      ogImage?: string;
+    };
+  };
+  message?: string;
+};
+
+type SearchWebPart = MessagePart & {
+  type: 'tool-searchWeb';
+  output?: SearchWebOutput;
+};
+
+type ScrapeUrlPart = MessagePart & {
+  type: 'tool-scrapeUrl';
+  output?: ScrapeUrlOutput;
+};
 
 const PurePreviewMessage = ({
   chatId,
@@ -399,15 +444,19 @@ const PurePreviewMessage = ({
                     );
                   }
 
-                  if ((part as any).type === 'tool-searchWeb') {
-                    const { toolCallId, state } = part as any;
+                  if (type === 'tool-searchWeb') {
+                    const searchPart = part as SearchWebPart;
+                    const { toolCallId, state } = searchPart;
+                    const output = searchPart.output as
+                      | SearchWebOutput
+                      | undefined;
 
                     return (
                       <Tool key={toolCallId} defaultOpen={true}>
                         <ToolHeader state={state} type="tool-searchWeb" />
                         <ToolContent>
                           {state === 'input-available' && (
-                            <ToolInput input={(part as any).input} />
+                            <ToolInput input={searchPart.input} />
                           )}
                           {state === 'output-error' && (
                             <ToolOutput
@@ -418,83 +467,75 @@ const PurePreviewMessage = ({
                                   </div>
                                   <div className="rounded-md bg-muted/50 p-2 text-xs">
                                     <CodeBlock
-                                      code={String(
-                                        (part as any).errorText || '',
-                                      )}
+                                      code={String(searchPart.errorText || '')}
                                       language="text"
                                     />
                                   </div>
                                 </div>
                               }
-                              errorText={(part as any).errorText}
+                              errorText={searchPart.errorText}
                             />
                           )}
                           {state === 'output-available' && (
                             <ToolOutput
                               output={
                                 <div className="min-w-0 space-y-3">
-                                  {(part as any).output?.summary && (
+                                  {output?.summary && (
                                     <div className="min-w-0 rounded-md bg-muted/50 p-2 text-xs">
                                       <div className="font-medium">Summary</div>
                                       <div className="break-words">
-                                        {(part as any).output.summary}
+                                        {output.summary}
                                       </div>
                                     </div>
                                   )}
                                   <div className="min-w-0 break-words text-muted-foreground text-xs">
                                     Query:{' '}
                                     <span className="break-all font-medium">
-                                      {(part as any).output?.query ??
-                                        (part as any).input?.query}
+                                      {output?.query ?? searchPart.input?.query}
                                     </span>
-                                    {typeof (part as any).output
-                                      ?.resultCount === 'number' && (
+                                    {typeof output?.resultCount ===
+                                      'number' && (
                                       <span>
                                         {' '}
-                                        • Results:{' '}
-                                        {(part as any).output.resultCount}
+                                        • Results: {output.resultCount}
                                       </span>
                                     )}
                                   </div>
-                                  {Array.isArray(
-                                    (part as any).output?.results,
-                                  ) &&
-                                    (part as any).output.results.length > 0 && (
+                                  {Array.isArray(output?.results) &&
+                                    output.results.length > 0 && (
                                       <div className="space-y-2">
-                                        {(part as any).output.results.map(
-                                          (r: any, i: number) => (
-                                            <div
-                                              key={r.url ?? i}
-                                              className="min-w-0 rounded-md border bg-background p-2"
-                                            >
-                                              <div className="min-w-0 break-words font-medium text-xs">
-                                                <a
-                                                  href={r.url}
-                                                  target="_blank"
-                                                  rel="noreferrer"
-                                                  className="break-all underline"
-                                                >
-                                                  {r.title || r.url}
-                                                </a>
-                                              </div>
-                                              {r.description && (
-                                                <div className="mt-1 line-clamp-3 break-words text-muted-foreground text-xs">
-                                                  {r.description}
-                                                </div>
-                                              )}
+                                        {output.results.map((r, i) => (
+                                          <div
+                                            key={r.url ?? i}
+                                            className="min-w-0 rounded-md border bg-background p-2"
+                                          >
+                                            <div className="min-w-0 break-words font-medium text-xs">
+                                              <a
+                                                href={r.url}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="break-all underline"
+                                              >
+                                                {r.title || r.url}
+                                              </a>
                                             </div>
-                                          ),
-                                        )}
+                                            {r.description && (
+                                              <div className="mt-1 line-clamp-3 break-words text-muted-foreground text-xs">
+                                                {r.description}
+                                              </div>
+                                            )}
+                                          </div>
+                                        ))}
                                       </div>
                                     )}
-                                  {(part as any).output?.privacy_notice && (
+                                  {output?.privacy_notice && (
                                     <div className="text-[10px] text-muted-foreground">
-                                      {(part as any).output.privacy_notice}
+                                      {output.privacy_notice}
                                     </div>
                                   )}
                                 </div>
                               }
-                              errorText={(part as any).errorText}
+                              errorText={searchPart.errorText}
                             />
                           )}
                         </ToolContent>
@@ -502,15 +543,19 @@ const PurePreviewMessage = ({
                     );
                   }
 
-                  if ((part as any).type === 'tool-scrapeUrl') {
-                    const { toolCallId, state } = part as any;
+                  if (type === 'tool-scrapeUrl') {
+                    const scrapePart = part as ScrapeUrlPart;
+                    const { toolCallId, state } = scrapePart;
+                    const output = scrapePart.output as
+                      | ScrapeUrlOutput
+                      | undefined;
 
                     return (
                       <Tool key={toolCallId} defaultOpen={true}>
                         <ToolHeader state={state} type="tool-scrapeUrl" />
                         <ToolContent>
                           {state === 'input-available' && (
-                            <ToolInput input={(part as any).input} />
+                            <ToolInput input={scrapePart.input} />
                           )}
                           {state === 'output-error' && (
                             <ToolOutput
@@ -521,15 +566,13 @@ const PurePreviewMessage = ({
                                   </div>
                                   <div className="rounded-md bg-muted/50 p-2 text-xs">
                                     <CodeBlock
-                                      code={String(
-                                        (part as any).errorText || '',
-                                      )}
+                                      code={String(scrapePart.errorText || '')}
                                       language="text"
                                     />
                                   </div>
                                 </div>
                               }
-                              errorText={(part as any).errorText}
+                              errorText={scrapePart.errorText}
                             />
                           )}
                           {state === 'output-available' && (
@@ -539,56 +582,46 @@ const PurePreviewMessage = ({
                                   <div className="min-w-0 break-words text-muted-foreground text-xs">
                                     Scraped:{' '}
                                     <span className="break-all font-medium">
-                                      {(part as any).output?.url ||
-                                        (part as any).input?.url}
+                                      {output?.url || scrapePart.input?.url}
                                     </span>
                                   </div>
-                                  {(part as any).output?.data?.metadata && (
+                                  {output?.data?.metadata && (
                                     <div className="min-w-0 rounded-md border bg-background p-2 text-xs">
                                       <div className="font-medium">
                                         Metadata
                                       </div>
                                       <div className="mt-1 grid grid-cols-1 gap-1 sm:grid-cols-2">
                                         <div className="min-w-0 break-words">
-                                          Title:{' '}
-                                          {
-                                            (part as any).output.data.metadata
-                                              .title
-                                          }
+                                          Title: {output.data.metadata.title}
                                         </div>
                                         <div className="min-w-0 break-words">
                                           Language:{' '}
-                                          {(part as any).output.data.metadata
-                                            .language || 'n/a'}
+                                          {output.data.metadata.language ||
+                                            'n/a'}
                                         </div>
                                         <div className="min-w-0 break-words">
                                           Status:{' '}
                                           {String(
-                                            (part as any).output.data.metadata
-                                              .statusCode ?? 'n/a',
+                                            output.data.metadata.statusCode ??
+                                              'n/a',
                                           )}
                                         </div>
                                         <div className="min-w-0 break-words">
                                           Source:{' '}
                                           <span className="break-all">
-                                            {
-                                              (part as any).output.data.metadata
-                                                .sourceURL
-                                            }
+                                            {output.data.metadata.sourceURL}
                                           </span>
                                         </div>
                                       </div>
                                     </div>
                                   )}
-                                  {(part as any).output?.data?.markdown && (
+                                  {output?.data?.markdown && (
                                     <div className="min-w-0 max-w-full rounded-md bg-muted/50 p-2 text-xs">
                                       <div className="font-medium">
                                         Markdown (preview)
                                       </div>
                                       <div className="mt-1 line-clamp-6 max-w-full whitespace-pre-wrap break-all [&_a]:break-all [&_a]:underline">
-                                        {(
-                                          part as any
-                                        ).output.data.markdown.slice(0, 2000)}
+                                        {output.data.markdown.slice(0, 2000)}
                                       </div>
                                     </div>
                                   )}
@@ -598,18 +631,14 @@ const PurePreviewMessage = ({
                                     </summary>
                                     <div className="mt-2 min-w-0 max-w-full overflow-hidden">
                                       <CodeBlock
-                                        code={JSON.stringify(
-                                          (part as any).output,
-                                          null,
-                                          2,
-                                        )}
+                                        code={JSON.stringify(output, null, 2)}
                                         language="json"
                                       />
                                     </div>
                                   </details>
                                 </div>
                               }
-                              errorText={(part as any).errorText}
+                              errorText={scrapePart.errorText}
                             />
                           )}
                         </ToolContent>

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,6 +15,7 @@
     "assistant": "Assistant",
     "apply": "Apply",
     "thinking": "Thinking...",
+    "thought": "Thought",
     "thoughtForSeconds": "Thought for {duration}s"
   },
   "App": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -101,8 +101,22 @@
     "thinking": "Thinking..."
   },
   "Tool": {
-    "title": {
-      "searchWeb": "Search the web for more information"
+    "error": "Error",
+    "result": "Result",
+    "searchWeb": {
+      "title": "Searching the web for more information",
+      "summary": "Summary",
+      "query": "Search query"
+    },
+    "scrapeUrl": {
+      "title": "Scraping the URL",
+      "scraped": "Scraped",
+      "metadata": "Metadata",
+      "outputTitle": "Title",
+      "language": "Language",
+      "statusCode": "Status Code",
+      "sourceURL": "Source URL",
+      "markdown": "Markdown (preview)"
     }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -99,5 +99,10 @@
   },
   "Message": {
     "thinking": "Thinking..."
+  },
+  "Tool": {
+    "title": {
+      "searchWeb": "Search the web for more information"
+    }
   }
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -99,5 +99,10 @@
   },
   "Message": {
     "thinking": "Tänker..."
+  },
+  "Tool": {
+    "title": {
+      "searchWeb": "Söker på webben efter mer information"
+    }
   }
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -15,6 +15,7 @@
     "assistant": "Assistent",
     "apply": "Använd",
     "thinking": "Tänker...",
+    "thought": "Tänkte",
     "thoughtForSeconds": "Tänkte i {duration} sekunder"
   },
   "App": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -101,8 +101,22 @@
     "thinking": "Tänker..."
   },
   "Tool": {
-    "title": {
-      "searchWeb": "Söker på webben efter mer information"
+    "error": "Fel",
+    "result": "Resultat",
+    "searchWeb": {
+      "title": "Söker på webben efter mer information",
+      "summary": "Sammanfattning",
+      "query": "Sökfråga"
+    },
+    "scrapeUrl": {
+      "title": "Läser in webbsida",
+      "scraped": "Läst in",
+      "metadata": "Metadata",
+      "outputTitle": "Titel",
+      "language": "Språk",
+      "statusCode": "Statuskod",
+      "sourceURL": "Käll-URL",
+      "markdown": "Markdown (förhandsvisning)"
     }
   }
 }


### PR DESCRIPTION
# Translate search and scrape tool

- Add i18n support for tool UI labels and messages
- Update search web tool strings to use translation keys
- Add translations for new scrape URL tool (title, scraped, metadata, language, status code, etc.)
- Add `ScanTextIcon` for scrape URL tool header
- Restructure translation keys under `Tool` namespace with nested objects for `searchWeb` and `scrapeUrl`
- Support both English and Swedish translations
- Minor UI improvements (padding adjustments in tool output)